### PR TITLE
Only call chown when necessary

### DIFF
--- a/src/s6-overlay-preinit/s6-overlay-preinit.c
+++ b/src/s6-overlay-preinit/s6-overlay-preinit.c
@@ -44,9 +44,21 @@ int main (void)
   }
 
   /* requirement: /var/run/s6 must be owned by current user */
-  if(chown(VAR_RUN_S6,getuid(),getgid()) == -1)
+  struct stat s6stat ;
+  if(stat(VAR_RUN_S6, &s6stat) == -1)
   {
-    strerr_diefu2sys(111,"chown ", VAR_RUN_S6) ;
+    strerr_diefu2sys(111, "stat ", VAR_RUN_S6) ;
+  }
+
+  uid_t uid = getuid() ,
+        gid = getgid() ;
+  /* only call chown if uid/gid are not from current user */
+  if(s6stat.st_uid != uid || s6stat.st_gid != gid) 
+  {
+    if (chown(VAR_RUN_S6, uid, gid) == -1)
+    {
+      strerr_diefu2sys(111, "chown ", VAR_RUN_S6) ;
+    }
   }
 
   return 0;


### PR DESCRIPTION
When a docker container is run with `--cap-drop=all` attribute, a number of syscalls are blocked, including `chown`. An image may be prepared in a way that already has `/var/run/s6` assigned to the designated user, but s6-overlay-preinit still makes a call to `chown` and fails.

This patch checks uid and gid permissions on `/var/run/s6` first and skips chown call if it is not needed.