### PR TITLE
Add riscv64 build

### DIFF
--- a/.github/build
+++ b/.github/build
@@ -19,6 +19,7 @@ targets=(
 'arm-linux-musleabi'
 'arm-linux-musleabihf'
 'powerpc64le-linux-musl'
+'riscv64-linux-musl'
 )
 
 declare -A target_short
@@ -28,6 +29,7 @@ target_short[aarch64-linux-musl]="aarch64"
 target_short[arm-linux-musleabi]="arm"
 target_short[arm-linux-musleabihf]="armhf"
 target_short[powerpc64le-linux-musl]="ppc64le"
+target_short[riscv64-linux-musl]="riscv64"
 
 declare -A versions
 versions[s6-overlay-preinit]=$(grep version package/info | cut -d'=' -f2)


### PR DESCRIPTION
I suggest to build s6-overlay-preinit, along with the other libraries included in s6-overlay for riscv64.

The project already supports many other architectures, and as far as I can tell, adding riscv64 would be quite easy - in this case, the musl-cross-make support is already present.

As far as I can see, this PR depends on a riscv64 compatible release of skaware, that is what https://github.com/just-containers/skaware/pull/51 is for.